### PR TITLE
to avoid Can't locate my_bio.pm in @INC

### DIFF
--- a/scripts/fasta_around_gap.pl
+++ b/scripts/fasta_around_gap.pl
@@ -1,5 +1,7 @@
 #!/usr/bin/perl
 
+use FindBin;
+use lib "$FindBin::Bin";
 use my_bio;
 
 (@ARGV != 2) and die "usage: $0 seq.fa around_length\n";


### PR DESCRIPTION
I found errors in *.combinatorialGapCloseLog in 6th iterate subdirectory as follows:

Can't locate my_bio.pm in @INC (you may need to install the my_bio module) (@INC contains: ...) at .../Platanus_B_v1.3.2/sub_bin/fasta_around_gap.pl line 3.

Comparison of fasta_around_gap.pl and other programs using my_bio appears that the two lines
```
    use FindBin;
    use lib "$FindBin::Bin";
```
before  
```
    use my_bio;
```
should allow the perl to locate the module.
